### PR TITLE
send-to-lava: Use the last item as the result

### DIFF
--- a/automated/linux/ltp-open-posix/ltp-open-posix.yaml
+++ b/automated/linux/ltp-open-posix/ltp-open-posix.yaml
@@ -22,9 +22,8 @@ params:
     # LTP version
     LTP_VERSION: 20180515
     SKIP_INSTALL: true
-
 run:
     steps:
         - cd ./automated/linux/ltp-open-posix/
-        - ./ltp-open-posix.sh -s "${SKIP_INSTALL}" -v "${LTP_VERSION}"
+        - ./ltp-open-posix.sh -s "${SKIP_INSTALL}" -v "${LTP_VERSION}" -t "${GRP_TEST}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/utils/send-to-lava.sh
+++ b/automated/utils/send-to-lava.sh
@@ -11,7 +11,7 @@ if [ -f "${RESULT_FILE}" ]; then
     while read -r line; do
         if echo "${line}" | grep -iq -E ".* +(pass|fail|skip|unknown)$"; then
             test="$(echo "${line}" | awk '{print $1}')"
-            result="$(echo "${line}" | awk '{print $2}')"
+            result="$(echo "${line}" | awk '{print $NF}')"
 
             if [ "${lava_test_case}" -eq 0 ]; then
                 lava-test-case "${test}" --result "${result}"


### PR DESCRIPTION
Some tests may have whitespace in the test name, so the "result" value
will be part of the test description, instead of the proper result. Use
the last item on that string to get the result in a more reliable way.