### PR TITLE
kselftest.sh: update rotine to handle skiptests

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -199,17 +199,6 @@ if [ -f "${SKIPFILE}" ] &&  [ -z "${SKIPLIST}" ]; then
     done < "${SKIPFILE}"
 fi
 
-cp kselftest-list.txt kselftest-list.txt.orig
-echo "skiplist:"
-echo "========================================"
-while read -r skip_regex; do
-    echo "$skip_regex"
-    # Remove matching tests from list of tests to run and report it as skipped
-    perl -i -ne 'if (s|^('"${skip_regex}"')$|\1 skip|) { print STDERR; } else { print; }' kselftest-list.txt 2>>"${RESULT_FILE}"
-done < "${skips}"
-echo "========================================"
-rm -f "${skips}"
-
 if [ -n "${TST_CASENAME}" ]; then
     ./run_kselftest.sh -t "${TST_CASENAME}" 2>&1 | tee -a "${LOGFILE}"
 elif [ -n "${TST_CMDFILES}" ]; then
@@ -218,6 +207,16 @@ elif [ -n "${TST_CMDFILES}" ]; then
         ./run_kselftest.sh -c ${test} 2>&1 | tee -a "${LOGFILE}"
     done
 else
+    cp kselftest-list.txt kselftest-list.txt.orig
+    echo "skiplist:"
+    echo "========================================"
+    while read -r skip_regex; do
+        echo "$skip_regex"
+        # Remove matching tests from list of tests to run and report it as skipped
+        perl -i -ne 'if (s|^('"${skip_regex}"')$|\1 skip|) { print STDERR; } else { print; }' kselftest-list.txt 2>>"${RESULT_FILE}"
+    done < "${skips}"
+    echo "========================================"
+    rm -f "${skips}"
     ./run_kselftest.sh 2>&1 | tee "${LOGFILE}"
 fi
 parse_output


### PR DESCRIPTION
update scripts to just print skiptests in cases of running all kselftests and avoid showing in results unrelated tests when only running specific collection or test cases.

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>