### PR TITLE
ltp/skipfile-lkft.yam: add ima_violations to skipfile

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -372,3 +372,14 @@ skiplist:
       - v4.4-rt
     tests:
       - ping01
+
+  - reason: >
+      ima_violations is require auditd daemon.
+    url: https://github.com/linux-test-project/ltp/issues/372
+    environments: all
+    boards:
+      - all
+    branches:
+      - all
+    tests:
+      - ima_violations


### PR DESCRIPTION
According to https://github.com/linux-test-project/ltp/issues/372, the ima_violations test is broken now. Skip it until that issue is fixed.

Signed-off-by: Dante Zhang <zhangyet@gmail.com>