### PR TITLE
automated: kselftest: explicitly set name of downloaded tarball

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -154,8 +154,8 @@ if [ -d "${KSELFTEST_PATH}" ]; then
 else
     # Fetch whatever we have been aimed at, assuming only that it can
     # be handled by "tar". Do not assume anything about the compression.
-    wget "${TESTPROG_URL}"
-    tar -xaf "$(basename "${TESTPROG_URL}")"
+    wget "${TESTPROG_URL}" -O "${TESTPROG}"
+    tar -xaf "${TESTPROG}"
     # shellcheck disable=SC3044
     if [ ! -e "run_kselftest.sh" ]; then cd "kselftest" || exit; fi
 fi


### PR DESCRIPTION
This patch always renames downloaded kselftest tarball to the value set in "TESTPROG". Default behaviour of the kselftest.sh script remains unchanged:

1) TESTPROG and TESTPROG_URL undefined: fall back to tarball/URL defaults
2) only TESTPROG defined: download specified test data from Linaro
3) only TESTPROG_URL defined: rename downloaded tarball to one of the defaults (based on architecture) but extract it immediately (so it's discarded anyway and the name becomes irrelevant)
4) both defined: specify name for the downloaded tarball

Case (4) is the only new branch added by this patch. Adjustments in case (3) should be transparent when running kselftest.sh script.

Fixes: #500

This PR will be closed if #501 gets merged